### PR TITLE
common: kernel parameter: disable NMI-like interrupts by default

### DIFF
--- a/common/overlays/common/etc/default/extlinux
+++ b/common/overlays/common/etc/default/extlinux
@@ -5,7 +5,7 @@ TIMEOUT="10"
 #DEFAULT="kernel-5.10"
 
 # Configure additional kernel configuration options
-APPEND="earlyprintk console=tty0 console=ttyAML0,115200n8 console=ttyS2,1500000n8 console=ttyFIQ0,1500000n8 coherent_pool=2M loglevel=4"
+APPEND="earlyprintk console=tty0 console=ttyAML0,115200n8 console=ttyS2,1500000n8 console=ttyFIQ0,1500000n8 coherent_pool=2M loglevel=4 irqchip.gicv3_pseudo_nmi=0"
 
 # Configure Device Tree overlays
 #FDTOVERLAYS=""


### PR DESCRIPTION
Signed-off-by: Stephen <stephen@radxa.com>