### PR TITLE
Make `date` invocation work with busybox

### DIFF
--- a/rbuild
+++ b/rbuild
@@ -741,7 +741,7 @@ fi
 
 SECONDS=0
 RBUILD_SHOW_EXECUTION_TIME="true"
-RBUILD_STARTING_TIME="$(date --iso-8601=m | tr -d :)"
+RBUILD_STARTING_TIME="$(date -Iminutes | tr -d :)"
 
 main "$@"
 


### PR DESCRIPTION
The `--iso-8601` flag is not supported in busybox date. It does support the `-I` flag, which is also supported in the GNU coreutil `date` implementation – they are in fact synonyms.

This improves portability ever so slightly.